### PR TITLE
feat: add BaseDomain to config and update related subroutines

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,4 +8,5 @@ type Config struct {
 	APIExportEndpointSliceName string `mapstructure:"api-export-endpoint-slice-name"`
 	CoreModulePath             string `mapstructure:"core-module-path"`
 	WorkspaceDir               string `mapstructure:"workspace-dir" default:"/operator/"`
+	BaseDomain                 string `mapstructure:"base-domain" default:"portal.dev.local"`
 }

--- a/internal/controller/initializer_controller.go
+++ b/internal/controller/initializer_controller.go
@@ -26,7 +26,7 @@ func NewLogicalClusterReconciler(log *logger.Logger, restCfg *rest.Config, cl, o
 		lifecycle: lifecyclecontrollerruntime.NewLifecycleManager(
 			[]lifecyclesubroutine.Subroutine{
 				subroutine.NewWorkspaceInitializer(cl, orgClient, restCfg, cfg),
-				subroutine.NewRealmSubroutine(inClusterClient),
+				subroutine.NewRealmSubroutine(inClusterClient, cfg.BaseDomain),
 			},
 			"logicalcluster",
 			"LogicalClusterReconciler",

--- a/internal/subroutine/realm.go
+++ b/internal/subroutine/realm.go
@@ -31,12 +31,14 @@ var (
 )
 
 type realmSubroutine struct {
-	k8s client.Client
+	k8s        client.Client
+	baseDomain string
 }
 
-func NewRealmSubroutine(k8s client.Client) *realmSubroutine {
+func NewRealmSubroutine(k8s client.Client, baseDomain string) *realmSubroutine {
 	return &realmSubroutine{
-		k8s: k8s,
+		k8s,
+		baseDomain,
 	}
 }
 
@@ -93,6 +95,9 @@ func (r *realmSubroutine) Process(ctx context.Context, instance lifecycleruntime
 			"client": map[string]interface{}{
 				"name":        workspaceName,
 				"displayName": workspaceName,
+				"validRedirectUris": []string{
+					fmt.Sprintf("https://%s.%s/callback*", workspaceName, r.baseDomain),
+				},
 			},
 		},
 		"keycloakConfig": map[string]interface{}{

--- a/internal/subroutine/realm_test.go
+++ b/internal/subroutine/realm_test.go
@@ -35,6 +35,7 @@ spec:
   releaseName: placeholder
   values: {}
 `
+	baseDomain = "portal.dev.local"
 )
 
 func newClientMock(t *testing.T, setup func(m *mocks.MockClient)) *mocks.MockClient {
@@ -174,7 +175,7 @@ func TestRealmSubroutine_ProcessAndFinalize(t *testing.T) {
 
 			repository, helmRelease = trim(repoYAML), trim(helmReleaseYAML)
 
-			rs := NewRealmSubroutine(clientMock)
+			rs := NewRealmSubroutine(clientMock, baseDomain)
 			lc := &kcpv1alpha1.LogicalCluster{}
 			lc.Annotations = map[string]string{"kcp.io/path": "root:orgs:test"}
 			res, opErr := rs.Process(context.Background(), lc)
@@ -190,7 +191,7 @@ func TestRealmSubroutine_ProcessAndFinalize(t *testing.T) {
 			})
 
 			repository, helmRelease = trim(repoYAML), trim(helmReleaseYAML)
-			rs := NewRealmSubroutine(clientMock)
+			rs := NewRealmSubroutine(clientMock, baseDomain)
 			lc := &kcpv1alpha1.LogicalCluster{}
 			lc.Annotations = map[string]string{"kcp.io/path": "root:orgs:test"}
 			res, opErr := rs.Process(context.Background(), lc)
@@ -201,7 +202,7 @@ func TestRealmSubroutine_ProcessAndFinalize(t *testing.T) {
 		t.Run("missing workspace annotation", func(t *testing.T) {
 			t.Parallel()
 			clientMock := newClientMock(t, nil)
-			rs := NewRealmSubroutine(clientMock)
+			rs := NewRealmSubroutine(clientMock, baseDomain)
 			lc := &kcpv1alpha1.LogicalCluster{}
 			res, opErr := rs.Process(context.Background(), lc)
 			require.NotNil(t, opErr)
@@ -246,7 +247,7 @@ func TestRealmSubroutine_ProcessAndFinalize(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				clientMock := newClientMock(t, tc.setupMocks)
-				rs := NewRealmSubroutine(clientMock)
+				rs := NewRealmSubroutine(clientMock, baseDomain)
 				lc := &kcpv1alpha1.LogicalCluster{}
 				lc.Annotations = map[string]string{"kcp.io/path": "root:orgs:test"}
 				res, opErr := rs.Finalize(context.Background(), lc)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable Base Domain (default: portal.dev.local) used to build workspace-specific callback URLs.
  - Automatically adds valid redirect URIs for authentication in the form: https://<workspace>.<base-domain>/callback*.
- Chores
  - Updated internal initialization to pass the configured Base Domain.
  - Adjusted tests to cover the new configuration-driven behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->