### PR TITLE
fix: remove secretRef from organization-idp repository configuration

### DIFF
--- a/internal/subroutine/manifests/organizationIdp/repository.yaml
+++ b/internal/subroutine/manifests/organizationIdp/repository.yaml
@@ -8,6 +8,3 @@ spec:
   url: oci://ghcr.io/platform-mesh/helm-charts/organization-idp
   ref:
     semver: "0.1.1"
-  secretRef:
-    name: github
-    


### PR DESCRIPTION
Remove `secretRef` for public repository.