### PR TITLE
fix: correct redirect_uri formatting in subroutine.go

### DIFF
--- a/internal/subroutine/invite/subroutine.go
+++ b/internal/subroutine/invite/subroutine.go
@@ -182,7 +182,7 @@ func (s *subroutine) Process(ctx context.Context, instance runtimeobject.Runtime
 	log.Debug().Str("email", invite.Spec.Email).Str("id", newUser.ID).Msg("User created")
 
 	queryParams := url.Values{
-		"redirect_uri": {fmt.Sprintf("https://%s.%s", realm, s.baseDomain)},
+		"redirect_uri": {fmt.Sprintf("https://%s.%s/", realm, s.baseDomain)},
 		"client_id":    {realm},
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirect URL formatting in user invitations to correctly include trailing slashes for proper downstream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->