### PR TITLE
feat: add toggles for initializer subroutines

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,13 @@ type InviteConfig struct {
 	KeycloakClientSecret string `mapstructure:"invite-keycloak-client-secret"`
 }
 
+type InitializerConfig struct {
+	WorkspaceInitializerEnabled bool `mapstructure:"initializer-workspace-enabled" default:"true"`
+	IDPEnabled                  bool `mapstructure:"initializer-idp-enabled" default:"true"`
+	InviteEnabled               bool `mapstructure:"initializer-invite-enabled" default:"true"`
+	WorkspaceAuthEnabled        bool `mapstructure:"initializer-workspace-auth-enabled" default:"true"`
+}
+
 // Config struct to hold the app config
 type Config struct {
 	FGA struct {
@@ -47,7 +54,8 @@ type Config struct {
 		AccessTokenLifespan int  `mapstructure:"idp-access-token-lifespan" default:"28800"`
 		RegistrationAllowed bool `mapstructure:"idp-registration-allowed" default:"false"`
 	} `mapstructure:",squash"`
-	Invite InviteConfig `mapstructure:",squash"`
+	Invite      InviteConfig      `mapstructure:",squash"`
+	Initializer InitializerConfig `mapstructure:",squash"`
 }
 
 func (config Config) InitializerName() string {


### PR DESCRIPTION
## Summary

- Add `InitializerConfig` struct with 4 boolean toggles to enable/disable each initializer subroutine independently
- Conditionally build subroutine list based on configuration
- All toggles default to `true` for backward compatibility

**New configuration options:**
| Flag | Default | Controls |
|------|---------|----------|
| `--initializer-workspace-enabled` | true | WorkspaceInitializer (FGA Store + AccountInfo) |
| `--initializer-idp-enabled` | true | IDPSubroutine (Keycloak configuration) |
| `--initializer-invite-enabled` | true | InviteSubroutine (org creator invites) |
| `--initializer-workspace-auth-enabled` | true | WorkspaceAuthConfigurationSubroutine (JWT auth) |

Note: `RemoveInitializer` always runs as it's the final cleanup step that marks initialization complete.