### PR TITLE
ci: add quality-gate status check

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -21,6 +21,7 @@ jobs:
       useLocalCoverageConfig: true
       coverageThresholdTotal: 90
   quality-gate:
+    permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -20,3 +20,8 @@ jobs:
       useTask: true
       useLocalCoverageConfig: true
       coverageThresholdTotal: 90
+  quality-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "OK"


### PR DESCRIPTION
## Summary

- Adds a no-op `quality-gate` job as a preparatory step for the CI workflow migration ([ADR 004](https://github.com/platform-mesh/architecture/blob/main/adr/004-shared-ci-workflow-strategy.md))

## Why is the quality-gate empty?

The org ruleset `main-go-app` currently requires specific status check names (`pipe / lint / lint`, etc.) that are tightly coupled to the shared pipeline structure. To decouple repos from that naming, we're introducing `quality-gate` as the single required check across all repos.

This no-op version exists only to emit the `quality-gate` check name so the org ruleset can be switched over. Once the ruleset requires `quality-gate`, each repo will be migrated individually to an inlined pipeline where `quality-gate` aggregates the actual CI jobs via `needs:` dependencies.

Ref: platform-mesh/backlog#216