### PR TITLE
feat: add --additional-audiences flag for workspace JWT authentication

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	Keycloak                         KeycloakConfig
 	Initializer                      InitializerConfig
 	Webhooks                         WebhooksConfig
+	AdditionalAudiences              []string
 }
 
 func NewConfig() Config {
@@ -167,6 +168,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.Initializer.IDPEnabled, "initializer-idp-enabled", c.Initializer.IDPEnabled, "Enable IDP initialization")
 	fs.BoolVar(&c.Initializer.InviteEnabled, "initializer-invite-enabled", c.Initializer.InviteEnabled, "Enable invite initialization")
 	fs.BoolVar(&c.Initializer.WorkspaceAuthEnabled, "initializer-workspace-auth-enabled", c.Initializer.WorkspaceAuthEnabled, "Enable workspace auth initialization")
+	fs.StringSliceVar(&c.AdditionalAudiences, "additional-audiences", c.AdditionalAudiences, "Additional audiences to trust in workspace JWT authentication configurations")
 	fs.BoolVar(&c.Webhooks.Enabled, "webhooks-enabled", c.Webhooks.Enabled, "Enable validating webhooks")
 	fs.IntVar(&c.Webhooks.Port, "webhooks-port", c.Webhooks.Port, "Set webhook server port")
 	fs.StringVar(&c.Webhooks.CertDir, "webhooks-cert-dir", c.Webhooks.CertDir, "Set webhook certificate directory")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "security-operator", cfg.Keycloak.ClientID)
 	assert.Equal(t, 9443, cfg.Webhooks.Port)
 	assert.Equal(t, []string{"http://localhost:8000", "http://localhost:18000"}, cfg.IDP.KubectlClientRedirectURLs)
+	assert.Nil(t, cfg.AdditionalAudiences)
 }
 
 func TestConfigAddFlags(t *testing.T) {
@@ -30,6 +31,7 @@ func TestConfigAddFlags(t *testing.T) {
 		"--idp-kubectl-client-redirect-urls=http://localhost:7000,http://localhost:17000",
 		"--webhooks-enabled=true",
 		"--webhooks-port=10443",
+		"--additional-audiences=aud-a,aud-b",
 	})
 
 	assert.NoError(t, err)
@@ -38,6 +40,7 @@ func TestConfigAddFlags(t *testing.T) {
 	assert.Equal(t, []string{"http://localhost:7000", "http://localhost:17000"}, cfg.IDP.KubectlClientRedirectURLs)
 	assert.True(t, cfg.Webhooks.Enabled)
 	assert.Equal(t, 10443, cfg.Webhooks.Port)
+	assert.Equal(t, []string{"aud-a", "aud-b"}, cfg.AdditionalAudiences)
 }
 
 func TestInitContainerConfigAddFlags(t *testing.T) {

--- a/internal/subroutine/workspace_authorization.go
+++ b/internal/subroutine/workspace_authorization.go
@@ -86,13 +86,14 @@ func (r *workspaceAuthSubroutine) reconcile(ctx context.Context, obj client.Obje
 		return subroutines.OK(), fmt.Errorf("AccountInfo %s has no OIDC clients", workspaceName)
 	}
 
-	audiences := make([]string, 0, len(accountInfo.Spec.OIDC.Clients))
+	audiences := make([]string, 0, len(accountInfo.Spec.OIDC.Clients)+len(r.cfg.AdditionalAudiences))
 	for clientName, clientInfo := range accountInfo.Spec.OIDC.Clients {
 		if clientInfo.ClientID == "" {
 			return subroutines.OK(), fmt.Errorf("OIDC client %s has empty ClientID in AccountInfo", clientName)
 		}
 		audiences = append(audiences, clientInfo.ClientID)
 	}
+	audiences = append(audiences, r.cfg.AdditionalAudiences...)
 
 	jwtAuthenticationConfiguration := kcptenancyv1alphav1.JWTAuthenticator{
 		Issuer: kcptenancyv1alphav1.Issuer{

--- a/internal/subroutine/workspace_authorization_test.go
+++ b/internal/subroutine/workspace_authorization_test.go
@@ -679,6 +679,109 @@ func TestWorkspaceAuthSubroutine_Initialize(t *testing.T) {
 			expectError:    true,
 			expectedResult: subroutines.OK(),
 		},
+		{
+			name: "success - additional audiences are appended",
+			logicalCluster: &kcpcorev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kcp.io/path": "root:orgs:test-workspace",
+					},
+				},
+			},
+			cfg: config.Config{
+				BaseDomain:          "test.domain",
+				GroupClaim:          "groups",
+				UserClaim:           "email",
+				AdditionalAudiences: []string{"extra-aud-1", "extra-aud-2"},
+			},
+			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
+				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						*obj.(*accountsv1alpha1.AccountInfo) = accountsv1alpha1.AccountInfo{
+							ObjectMeta: metav1.ObjectMeta{Name: "account"},
+							Spec: accountsv1alpha1.AccountInfoSpec{
+								OIDC: &accountsv1alpha1.OIDCInfo{
+									Clients: map[string]accountsv1alpha1.ClientInfo{
+										"test-workspace": {ClientID: "test-workspace-client"},
+										"kubectl":        {ClientID: "kubectl-client"},
+									},
+								},
+							},
+						}
+						return nil
+					}).Once()
+				m.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "test-workspace"}, mock.AnythingOfType("*v1alpha1.WorkspaceAuthenticationConfiguration"), mock.Anything).
+					Return(apierrors.NewNotFound(kcptenancyv1alphav1.Resource("workspaceauthenticationconfigurations"), "test-workspace")).Once()
+				m.EXPECT().Create(mock.Anything, mock.AnythingOfType("*v1alpha1.WorkspaceAuthenticationConfiguration"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						wac := obj.(*kcptenancyv1alphav1.WorkspaceAuthenticationConfiguration)
+						assert.Equal(t, "test-workspace", wac.Name)
+						assert.ElementsMatch(t, []string{"test-workspace-client", "kubectl-client", "extra-aud-1", "extra-aud-2"}, wac.Spec.JWT[0].Issuer.Audiences)
+						return nil
+					}).Once()
+
+				m.EXPECT().List(mock.Anything, mock.AnythingOfType("*v1alpha1.WorkspaceTypeList"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						wtList := list.(*kcptenancyv1alphav1.WorkspaceTypeList)
+						wtList.Items = []kcptenancyv1alphav1.WorkspaceType{}
+						return nil
+					}).Once()
+			},
+			expectError:    false,
+			expectedResult: subroutines.OK(),
+		},
+		{
+			name: "success - empty additional audiences does not change behavior",
+			logicalCluster: &kcpcorev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kcp.io/path": "root:orgs:test-workspace",
+					},
+				},
+			},
+			cfg: config.Config{
+				BaseDomain:          "test.domain",
+				GroupClaim:          "groups",
+				UserClaim:           "email",
+				AdditionalAudiences: []string{},
+			},
+			setupMocks: func(m *mocks.MockClient, mgrClient *mocks.MockClient) {
+				mgrClient.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "account"}, mock.AnythingOfType("*v1alpha1.AccountInfo"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						*obj.(*accountsv1alpha1.AccountInfo) = accountsv1alpha1.AccountInfo{
+							ObjectMeta: metav1.ObjectMeta{Name: "account"},
+							Spec: accountsv1alpha1.AccountInfoSpec{
+								OIDC: &accountsv1alpha1.OIDCInfo{
+									Clients: map[string]accountsv1alpha1.ClientInfo{
+										"test-workspace": {ClientID: "test-workspace-client"},
+										"kubectl":        {ClientID: "kubectl-client"},
+									},
+								},
+							},
+						}
+						return nil
+					}).Once()
+				m.EXPECT().Get(mock.Anything, types.NamespacedName{Name: "test-workspace"}, mock.AnythingOfType("*v1alpha1.WorkspaceAuthenticationConfiguration"), mock.Anything).
+					Return(apierrors.NewNotFound(kcptenancyv1alphav1.Resource("workspaceauthenticationconfigurations"), "test-workspace")).Once()
+				m.EXPECT().Create(mock.Anything, mock.AnythingOfType("*v1alpha1.WorkspaceAuthenticationConfiguration"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						wac := obj.(*kcptenancyv1alphav1.WorkspaceAuthenticationConfiguration)
+						assert.Equal(t, "test-workspace", wac.Name)
+						assert.ElementsMatch(t, []string{"test-workspace-client", "kubectl-client"}, wac.Spec.JWT[0].Issuer.Audiences)
+						assert.Len(t, wac.Spec.JWT[0].Issuer.Audiences, 2)
+						return nil
+					}).Once()
+
+				m.EXPECT().List(mock.Anything, mock.AnythingOfType("*v1alpha1.WorkspaceTypeList"), mock.Anything).
+					RunAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						wtList := list.(*kcptenancyv1alphav1.WorkspaceTypeList)
+						wtList.Items = []kcptenancyv1alphav1.WorkspaceType{}
+						return nil
+					}).Once()
+			},
+			expectError:    false,
+			expectedResult: subroutines.OK(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `--additional-audiences` CLI flag (`[]string`) to append extra trusted audiences to the `WorkspaceAuthenticationConfiguration` JWT issuer, beyond those derived from OIDC clients in AccountInfo
- Available on all subcommands (`operator`, `initializer`, `terminator`, `system`, `model-generator`) via `Config.AddFlags()`
- No behavior change when the flag is not set (nil slice is a no-op on append)