### PR TITLE
fix(security-operator): address AuthorizationModel StoreRef at the org's generated cluster

### DIFF
--- a/internal/subroutine/authorization_model_generation.go
+++ b/internal/subroutine/authorization_model_generation.go
@@ -285,7 +285,7 @@ func (a *AuthorizationModelGenerationSubroutine) Process(ctx context.Context, ob
 				Model: buffer.String(),
 				StoreRef: securityv1alpha1.WorkspaceStoreRef{
 					Name:    accountInfo.Spec.Organization.Name,
-					Cluster: accountInfo.Spec.Organization.OriginClusterId,
+					Cluster: accountInfo.Spec.Organization.GeneratedClusterId,
 				},
 			}
 			return nil

--- a/internal/subroutine/authorization_model_generation_test.go
+++ b/internal/subroutine/authorization_model_generation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	accountv1alpha1 "github.com/platform-mesh/account-operator/api/v1alpha1"
+	securityv1alpha1 "github.com/platform-mesh/security-operator/api/v1alpha1"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/security-operator/internal/subroutine/mocks"
 	"github.com/stretchr/testify/assert"
@@ -43,9 +44,14 @@ func bindingWithApiExportCluster(name, path, exportCluster string) *kcpapisv1alp
 }
 
 func mockAccountInfo(cl *mocks.MockClient, orgName, originCluster string) {
+	mockAccountInfoWithClusters(cl, orgName, originCluster, originCluster)
+}
+
+func mockAccountInfoWithClusters(cl *mocks.MockClient, orgName, generatedCluster, originCluster string) {
 	cl.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o client.Object, opts ...client.GetOption) error {
 		if acc, ok := o.(*accountv1alpha1.AccountInfo); ok {
 			acc.Spec.Organization.Name = orgName
+			acc.Spec.Organization.GeneratedClusterId = generatedCluster
 			acc.Spec.Organization.OriginClusterId = originCluster
 		}
 		return nil
@@ -303,6 +309,48 @@ func TestAuthorizationModelGeneration_Process(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthorizationModelGeneration_Process_UsesGeneratedClusterForStoreRef(t *testing.T) {
+	manager := mocks.NewMockManager(t)
+	allClient := mocks.NewMockClient(t)
+	cluster := mocks.NewMockCluster(t)
+	kcpClient := mocks.NewMockClient(t)
+
+	manager.EXPECT().ClusterFromContext(mock.Anything).Return(cluster, nil)
+	cluster.EXPECT().GetClient().Return(kcpClient)
+	mockAccountInfoWithClusters(kcpClient, "org", "generated-org-cluster", "origin-org-cluster")
+	manager.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil)
+	kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o client.Object, opts ...client.GetOption) error {
+		if ae, ok := o.(*kcpapisv1alpha2.APIExport); ok {
+			ae.Spec.Resources = []kcpapisv1alpha2.ResourceSchema{{Schema: "schema1"}}
+			return nil
+		}
+		return nil
+	}).Once()
+	kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o client.Object, opts ...client.GetOption) error {
+		if rs, ok := o.(*kcpapisv1alpha1.APIResourceSchema); ok {
+			rs.Spec.Group = "operations.openkcm.io"
+			rs.Spec.Names.Plural = "servicekeys"
+			rs.Spec.Names.Singular = "servicekey"
+			rs.Spec.Scope = apiextensionsv1.NamespaceScoped
+			return nil
+		}
+		return nil
+	}).Once()
+	kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
+		kerrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "servicekeys-org"),
+	).Once()
+	kcpClient.EXPECT().Create(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+		model := obj.(*securityv1alpha1.AuthorizationModel)
+		assert.Equal(t, "generated-org-cluster", model.Spec.StoreRef.Cluster)
+		assert.Equal(t, "org", model.Spec.StoreRef.Name)
+		return nil
+	}).Once()
+
+	sub := subroutine.NewAuthorizationModelGenerationSubroutine(manager, allClient)
+	_, err := sub.Process(context.Background(), newApiBinding("operations.openkcm.io", "root:providers:openkcm-provider"))
+	assert.Nil(t, err)
 }
 
 func TestAuthorizationModelGeneration_Finalize(t *testing.T) {

--- a/internal/subroutine/authorization_model_generation_test.go
+++ b/internal/subroutine/authorization_model_generation_test.go
@@ -330,16 +330,16 @@ func TestAuthorizationModelGeneration_Process_UsesGeneratedClusterForStoreRef(t 
 	}).Once()
 	kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, nn types.NamespacedName, o client.Object, opts ...client.GetOption) error {
 		if rs, ok := o.(*kcpapisv1alpha1.APIResourceSchema); ok {
-			rs.Spec.Group = "operations.openkcm.io"
-			rs.Spec.Names.Plural = "servicekeys"
-			rs.Spec.Names.Singular = "servicekey"
+			rs.Spec.Group = "example.io"
+			rs.Spec.Names.Plural = "widgets"
+			rs.Spec.Names.Singular = "widget"
 			rs.Spec.Scope = apiextensionsv1.NamespaceScoped
 			return nil
 		}
 		return nil
 	}).Once()
 	kcpClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(
-		kerrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "servicekeys-org"),
+		kerrors.NewNotFound(schema.GroupResource{Group: "core.platform-mesh.io", Resource: "authorizationmodels"}, "widgets-org"),
 	).Once()
 	kcpClient.EXPECT().Create(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 		model := obj.(*securityv1alpha1.AuthorizationModel)
@@ -349,7 +349,7 @@ func TestAuthorizationModelGeneration_Process_UsesGeneratedClusterForStoreRef(t 
 	}).Once()
 
 	sub := subroutine.NewAuthorizationModelGenerationSubroutine(manager, allClient)
-	_, err := sub.Process(context.Background(), newApiBinding("operations.openkcm.io", "root:providers:openkcm-provider"))
+	_, err := sub.Process(context.Background(), newApiBinding("example.io", "root:providers:example"))
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
## Summary
- Fix `AuthorizationModel` generation so `StoreRef.Cluster` points at the organization workspace's `GeneratedClusterId`, not `OriginClusterId`.
- Add one focused regression test proving generated provider models reference `Organization.GeneratedClusterId`.

## Why
`StoreRef` is used to find the KCP workspace that hosts the org's OpenFGA `Store`. `OriginClusterId` is used in FGA tuple object strings; it is not the workspace logical cluster that owns the store. `GeneratedClusterId` is the org workspace identity and is already the value used by the finalizer path when grouping bindings by organization.

## Scope
Minimal bug fix only:
- one production-line change in `AuthorizationModelGeneration.Process`
- one generic regression test

## Testing
- `go test ./internal/subroutine -count=1`
- `task lint`

Local full `task test` was attempted but this workstation has another process bound to `:8080`, which breaks the existing integration test manager startup. I did not include the test-harness metrics-port fix in this PR to keep scope minimal.
