### PR TITLE
test: add CRD roundtrip and webhook fuzz tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -118,6 +118,18 @@ tasks:
     cmds:
       - go run ./cmd/main.go operator
 
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzStoreRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAuthorizationModelRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAPIExportPolicyRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzIdentityProviderConfigurationRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzInviteRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./internal/webhook/ -run=^$ -fuzz=FuzzIdentityProviderConfigurationValidateCreate -fuzztime={{.FUZZTIME}} -count=1
+
   docker:kind:load:
     desc: "Build container image with current tag from kind cluster and load it into kind"
     vars:

--- a/api/v1alpha1/roundtrip_fuzz_test.go
+++ b/api/v1alpha1/roundtrip_fuzz_test.go
@@ -1,0 +1,83 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func FuzzStoreRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"spec":{"coreModule":"module","tuples":[{"object":"doc:1","relation":"viewer","user":"user:anne"}]}}`))
+	f.Add([]byte(`{"status":{"storeID":"s1","authorizationModelID":"am1","managedTuples":[{"object":"o","relation":"r","user":"u"}]}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &Store{}, &Store{})
+	})
+}
+
+func FuzzAuthorizationModelRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"spec":{"storeRef":{"name":"store","cluster":"cl1"},"model":"model openfga/v1","tuples":[{"object":"doc:1","relation":"viewer","user":"user:anne"}]}}`))
+	f.Add([]byte(`{"status":{"managedTuples":[{"object":"o","relation":"r","user":"u"}]}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &AuthorizationModel{}, &AuthorizationModel{})
+	})
+}
+
+func FuzzAPIExportPolicyRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"spec":{"apiExportRef":{"name":"export","clusterPath":"root:org"},"allowPathExpressions":["root:org:*"]}}`))
+	f.Add([]byte(`{"status":{"managedAllowExpressions":["root:org:ws1"]}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &APIExportPolicy{}, &APIExportPolicy{})
+	})
+}
+
+func FuzzIdentityProviderConfigurationRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"spec":{"registrationAllowed":true,"clients":[{"clientType":"confidential","clientName":"app","redirectURIs":["https://app/callback"]}]}}`))
+	f.Add([]byte(`{"status":{"managedClients":{"app":{"clientID":"c1","registrationClientURI":"https://kc/clients/c1"}}}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &IdentityProviderConfiguration{}, &IdentityProviderConfiguration{})
+	})
+}
+
+func FuzzInviteRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"spec":{"email":"user@example.com"}}`))
+	f.Add([]byte(`{"spec":{"email":""}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &Invite{}, &Invite{})
+	})
+}
+
+// fuzzRoundTrip unmarshals arbitrary JSON into obj, marshals it back, unmarshals
+// into obj2, and checks semantic equality. We use equality.Semantic.DeepEqual from
+// k8s.io/apimachinery which treats nil and empty slices/maps as equivalent — the
+// standard Kubernetes comparison semantic for API objects.
+func fuzzRoundTrip[T any](t *testing.T, data []byte, obj *T, obj2 *T) {
+	t.Helper()
+
+	if err := json.Unmarshal(data, obj); err != nil {
+		return
+	}
+
+	roundtripped, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	if err := json.Unmarshal(roundtripped, obj2); err != nil {
+		t.Fatalf("failed to unmarshal roundtripped data: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(obj, obj2) {
+		t.Errorf("roundtrip mismatch for %T", obj)
+	}
+}

--- a/internal/webhook/webhook_fuzz_test.go
+++ b/internal/webhook/webhook_fuzz_test.go
@@ -1,0 +1,49 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/platform-mesh/security-operator/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func FuzzIdentityProviderConfigurationValidateCreate(f *testing.F) {
+	f.Add("my-realm", "admin,master,system")
+	f.Add("master", "")
+	f.Add("", "")
+	f.Add("   ", "blocked")
+	f.Add("valid-realm", "org1,org2")
+
+	f.Fuzz(func(t *testing.T, name, denyListCSV string) {
+		var denyList []string
+		if denyListCSV != "" {
+			denyList = splitCSV(denyListCSV)
+		}
+
+		idp := &v1alpha1.IdentityProviderConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+		v := &identityProviderConfigurationValidator{
+			keycloakClient: fakeRealmChecker{exists: false},
+			realmDenyList:  denyList,
+		}
+
+		// Must not panic — validation errors are expected
+		_, _ = v.ValidateCreate(context.Background(), idp)
+	})
+}
+
+func splitCSV(s string) []string {
+	var result []string
+	start := 0
+	for i := range len(s) {
+		if s[i] == ',' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}


### PR DESCRIPTION
## Summary

- Add Go native roundtrip fuzz tests for all five CRD types (`Store`, `AuthorizationModel`, `APIExportPolicy`, `IdentityProviderConfiguration`, `Invite`) using `k8s.io/apimachinery/pkg/api/equality`
- Add fuzz test for `IdentityProviderConfiguration` webhook validator ensuring it never panics on arbitrary realm names and deny lists
- Add `task fuzz` to Taskfile with configurable `FUZZTIME` (default 30s per target)

Seed corpus runs as regular unit tests during `go test ./...` — no CI changes needed.

Closes #484
Ref platform-mesh/backlog#231