### PR TITLE
Add Prometheus custom metrics to security-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/platform-mesh/account-operator v0.14.30
 	github.com/platform-mesh/golang-commons v0.16.12
 	github.com/platform-mesh/subroutines v0.4.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -80,6 +81,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.31.1 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/martinlindhe/base36 v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
@@ -91,7 +93,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pquerna/cachecontrol v0.2.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/accountinfo_controller.go
+++ b/internal/controller/accountinfo_controller.go
@@ -2,11 +2,13 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	accountv1alpha1 "github.com/platform-mesh/account-operator/api/v1alpha1"
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
 	"github.com/platform-mesh/golang-commons/logger"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/lifecycle"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,7 +37,15 @@ func NewAccountInfoReconciler(log *logger.Logger, mcMgr mcmanager.Manager) *Acco
 }
 
 func (r *AccountInfoReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("accountinfo", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("accountinfo").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *AccountInfoReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/accountlogicalcluster_controller.go
+++ b/internal/controller/accountlogicalcluster_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
@@ -12,6 +13,7 @@ import (
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
 	"github.com/platform-mesh/security-operator/internal/fga"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/lifecycle"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,7 +62,15 @@ func NewAccountLogicalClusterController(log *logger.Logger, cfg config.Config, f
 }
 
 func (r *AccountLogicalClusterController) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues(r.name, labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues(r.name).Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *AccountLogicalClusterController) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/apibinding_controller.go
+++ b/internal/controller/apibinding_controller.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
 	"github.com/platform-mesh/golang-commons/logger"
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/lifecycle"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,7 +40,15 @@ type APIBindingReconciler struct {
 }
 
 func (r *APIBindingReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("apibinding", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("apibinding").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *APIBindingReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/apiexportpolicy_controller.go
+++ b/internal/controller/apiexportpolicy_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"strings"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	accountsv1alpha1 "github.com/platform-mesh/account-operator/api/v1alpha1"
@@ -13,6 +14,7 @@ import (
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
 	"github.com/platform-mesh/security-operator/internal/fga"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/conditions"
 	"github.com/platform-mesh/subroutines/lifecycle"
@@ -55,7 +57,15 @@ func NewAPIExportPolicyReconciler(log *logger.Logger, fgaClient openfgav1.OpenFG
 }
 
 func (r *APIExportPolicyReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("apiexportpolicy", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("apiexportpolicy").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *APIExportPolicyReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/authorization_model_controller.go
+++ b/internal/controller/authorization_model_controller.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
 	"github.com/platform-mesh/golang-commons/logger"
 	corev1alpha1 "github.com/platform-mesh/security-operator/api/v1alpha1"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/lifecycle"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,7 +38,15 @@ func NewAuthorizationModelReconciler(log *logger.Logger, fga openfgav1.OpenFGASe
 }
 
 func (r *AuthorizationModelReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("authorizationmodel", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("authorizationmodel").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *AuthorizationModelReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/idp_controller.go
+++ b/internal/controller/idp_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
@@ -12,6 +13,7 @@ import (
 	corev1alpha1 "github.com/platform-mesh/security-operator/api/v1alpha1"
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine/idp"
 	"github.com/platform-mesh/subroutines/conditions"
 	"github.com/platform-mesh/subroutines/lifecycle"
@@ -58,7 +60,15 @@ func NewIdentityProviderConfigurationReconciler(ctx context.Context, mgr mcmanag
 }
 
 func (r *IdentityProviderConfigurationReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("identityprovider", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("identityprovider").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *IdentityProviderConfigurationReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, log *logger.Logger, evp ...predicate.Predicate) error {

--- a/internal/controller/invite_controller.go
+++ b/internal/controller/invite_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
@@ -11,6 +12,7 @@ import (
 	"github.com/platform-mesh/security-operator/api/v1alpha1"
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine/invite"
 	"github.com/platform-mesh/subroutines/conditions"
 	"github.com/platform-mesh/subroutines/lifecycle"
@@ -55,7 +57,15 @@ func NewInviteReconciler(ctx context.Context, mgr mcmanager.Manager, cfg *config
 }
 
 func (r *InviteReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("invite", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("invite").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *InviteReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, log *logger.Logger) error {

--- a/internal/controller/orglogicalcluster_controller.go
+++ b/internal/controller/orglogicalcluster_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
 	"github.com/platform-mesh/golang-commons/controller/filter"
@@ -10,6 +11,7 @@ import (
 	"github.com/platform-mesh/golang-commons/logger"
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines"
 	"github.com/platform-mesh/subroutines/lifecycle"
@@ -89,7 +91,15 @@ func NewOrgLogicalClusterController(log *logger.Logger, kcpClientGetter iclient.
 }
 
 func (r *OrgLogicalClusterController) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues(r.name, labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues(r.name).Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 func (r *OrgLogicalClusterController) SetupWithManager(mgr mcmanager.Manager, cfg *platformeshconfig.CommonServiceConfig, evp ...predicate.Predicate) error {

--- a/internal/controller/store_controller.go
+++ b/internal/controller/store_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	platformeshconfig "github.com/platform-mesh/golang-commons/config"
@@ -10,6 +11,7 @@ import (
 	corev1alpha1 "github.com/platform-mesh/security-operator/api/v1alpha1"
 	iclient "github.com/platform-mesh/security-operator/internal/client"
 	"github.com/platform-mesh/security-operator/internal/config"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 	"github.com/platform-mesh/security-operator/internal/subroutine"
 	"github.com/platform-mesh/subroutines/conditions"
 	"github.com/platform-mesh/subroutines/lifecycle"
@@ -57,7 +59,15 @@ func NewStoreReconciler(ctx context.Context, log *logger.Logger, fga openfgav1.O
 }
 
 func (r *StoreReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	start := time.Now()
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	labelResult := "success"
+	if err != nil {
+		labelResult = "error"
+	}
+	metrics.ReconcileTotal.WithLabelValues("store", labelResult).Inc()
+	metrics.ReconcileDuration.WithLabelValues("store").Observe(time.Since(start).Seconds())
+	return result, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/fga/tuple_manager.go
+++ b/internal/fga/tuple_manager.go
@@ -7,6 +7,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/platform-mesh/golang-commons/logger"
 	"github.com/platform-mesh/security-operator/api/v1alpha1"
+	"github.com/platform-mesh/security-operator/internal/metrics"
 )
 
 // AuthorizationModelIDLatest is to explicitely acknowledge that no ID means
@@ -57,10 +58,12 @@ func (m *TupleManager) Apply(ctx context.Context, tuples []v1alpha1.Tuple) error
 		},
 	})
 	if err != nil {
+		metrics.FGAOperations.WithLabelValues("apply", "error").Inc()
 		return err
 	}
 
 	m.logger.Debug().Int("count", len(tuples)).Msg("Ensured tuples")
+	metrics.FGAOperations.WithLabelValues("apply", "success").Inc()
 	return nil
 }
 
@@ -89,10 +92,12 @@ func (m *TupleManager) Delete(ctx context.Context, tuples []v1alpha1.Tuple) erro
 		},
 	})
 	if err != nil {
+		metrics.FGAOperations.WithLabelValues("delete", "error").Inc()
 		return err
 	}
 
 	m.logger.Debug().Int("count", len(tuples)).Msg("Deleted tuples")
+	metrics.FGAOperations.WithLabelValues("delete", "success").Inc()
 	return nil
 }
 
@@ -112,6 +117,7 @@ func (m *TupleManager) ListWithFilter(ctx context.Context, filter TupleFilter) (
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
+			metrics.FGAOperations.WithLabelValues("list", "error").Inc()
 			return nil, err
 		}
 
@@ -135,6 +141,7 @@ func (m *TupleManager) ListWithFilter(ctx context.Context, filter TupleFilter) (
 		}
 	}
 
+	metrics.FGAOperations.WithLabelValues("list", "success").Inc()
 	return result, nil
 }
 
@@ -150,6 +157,7 @@ func (m *TupleManager) ListWithKey(ctx context.Context, key *openfgav1.ReadReque
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
+			metrics.FGAOperations.WithLabelValues("list", "error").Inc()
 			return nil, err
 		}
 
@@ -170,5 +178,6 @@ func (m *TupleManager) ListWithKey(ctx context.Context, key *openfgav1.ReadReque
 		}
 	}
 
+	metrics.FGAOperations.WithLabelValues("list", "success").Inc()
 	return result, nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// ReconcileTotal counts reconcile calls per controller and result (success/error).
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "security_operator_reconcile_total",
+			Help: "Total number of reconcile calls by controller and result.",
+		},
+		[]string{"controller", "result"},
+	)
+
+	// ReconcileDuration observes how long each reconcile loop takes, labelled by controller.
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "security_operator_reconcile_duration_seconds",
+			Help:    "Duration of reconcile calls in seconds by controller.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"controller"},
+	)
+
+	// FGAOperations counts OpenFGA tuple operations by operation (apply/delete/list) and result.
+	FGAOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "security_operator_fga_operations_total",
+			Help: "Total number of OpenFGA tuple operations by operation and result.",
+		},
+		[]string{"operation", "result"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		ReconcileTotal,
+		ReconcileDuration,
+		FGAOperations,
+	)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,53 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/platform-mesh/security-operator/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
+
+// TestReconcileTotal verifies that the ReconcileTotal counter increments
+// correctly for each controller/result label combination.
+func (s *MetricsTestSuite) TestReconcileTotal() {
+	before := testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("store", "success"))
+	metrics.ReconcileTotal.WithLabelValues("store", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("store", "success")))
+
+	before = testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("invite", "error"))
+	metrics.ReconcileTotal.WithLabelValues("invite", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.ReconcileTotal.WithLabelValues("invite", "error")))
+}
+
+// TestReconcileDuration verifies that the ReconcileDuration histogram records
+// observations per controller label.
+func (s *MetricsTestSuite) TestReconcileDuration() {
+	before := testutil.CollectAndCount(metrics.ReconcileDuration)
+	metrics.ReconcileDuration.WithLabelValues("store").Observe(0.05)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.ReconcileDuration), before)
+}
+
+// TestFGAOperations verifies that the FGAOperations counter increments
+// correctly for each operation/result label combination.
+func (s *MetricsTestSuite) TestFGAOperations() {
+	before := testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("apply", "success"))
+	metrics.FGAOperations.WithLabelValues("apply", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("apply", "success")))
+
+	before = testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("delete", "error"))
+	metrics.FGAOperations.WithLabelValues("delete", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("delete", "error")))
+
+	before = testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("list", "success"))
+	metrics.FGAOperations.WithLabelValues("list", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.FGAOperations.WithLabelValues("list", "success")))
+}


### PR DESCRIPTION
### **Description**
Adds an `internal/metrics` package to security-operator and wires custom Prometheus
metrics across all 9 reconcilers and the OpenFGA tuple manager.

### **Testing**
`go test ./internal/metrics/... -v`